### PR TITLE
docs: session handover and learnings (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,9 +519,21 @@ For production factorization, use established tools like [CADO-NFS](https://cado
 
 ## Session Handover
 
-### Last Updated: October 29, 2025 10:31 AM JST
+### Last Updated: October 29, 2025 06:30 PM JST
 
 #### Recently Completed
+- ✅ [PR #18](https://github.com/TheIllusionOfLife/Factorization/pull/18): Meta-Learning for Adaptive Operator Selection (Week 7-8)
+  - Implemented adaptive operator rate selection using UCB1 algorithm for exploration-exploitation balance
+  - Added MetaLearningEngine with comprehensive bounds validation and iterative rate adjustment
+  - Operator metadata tracking: provenance (crossover/mutation/random), parent fitness, generation
+  - JSON export for analysis with rate history and operator statistics alignment
+  - 38 new tests (164 total passing): bounds validation, convergence warnings, integration tests
+  - Fixed 8 reviewer issues systematically: 3 Critical (infinite score path, bounds enforcement, data alignment), 2 High (parent fitness calculation, initial rate storage), 3 Medium
+  - Addressed post-commit claude-review feedback: 4 additional tests, mutation prevention in getters, warning stacklevels for proper source tracking
+  - All CI checks passing (Lint, Type check, Tests on Python 3.9/3.10/3.11, CodeRabbit, claude-review)
+  - Feature: `--meta-learning`, `--adaptation-window N` CLI arguments
+
+#### Recently Completed (Previous Sessions)
 - ✅ [PR #16](https://github.com/TheIllusionOfLife/Factorization/pull/16): Add comparison results visualization notebook
   - Created comprehensive Jupyter notebook with 5 publication-quality plots
   - Fitness evolution curves with mean/std bands and baseline comparisons
@@ -576,13 +588,22 @@ For production factorization, use established tools like [CADO-NFS](https://cado
    - Fixed in commit `010fac1`
 
 #### Next Priority Tasks
-1. **Add Production Logging Configuration** (Optional Enhancement)
+1. **Documentation Clarity Improvements** (Low Priority - Polish)
+   - Source: PR #18 post-merge review feedback
+   - Context: Two LOW priority suggestions from final review
+   - Tasks:
+     - Update docs to clarify "continuously adapts using rolling N-generation window" (currently says "adapt every N generations")
+     - Extract `MAX_CONVERGENCE_ITERATIONS = 20` constant in adaptive_engine.py:319
+   - Approach: Quick doc update + constant extraction (5-10 minutes)
+   - Priority: LOW (cosmetic improvements, functionality correct)
+
+2. **Add Production Logging Configuration** (Optional Enhancement)
    - Source: PR #2 review feedback (low priority)
    - Context: Logger created but not configured with appropriate log levels
    - Approach: Add logging config with environment-based levels (DEBUG/INFO/WARNING)
    - Priority: Low (nice-to-have for production deployment)
 
-2. **Extract Magic Numbers to Config** (Optional Enhancement)
+3. **Extract Magic Numbers to Config** (Optional Enhancement)
    - Source: PR #2 review feedback (low priority)
    - Context: Hardcoded percentages (0.2 for elite selection, 0.8/1.2 temperatures)
    - Approach: Move to configuration constants for tuneability
@@ -592,16 +613,14 @@ For production factorization, use established tools like [CADO-NFS](https://cado
 - None currently blocking development
 
 #### Session Learnings
-- **Jupyter Notebook Edge Case Robustness** (PR #16): Always use `.get()` with defaults for JSON keys, check empty collections before operations, handle None before formatting, use conditional expressions for division by zero - prevents crashes on edge cases like 0% convergence or baseline=0
-- **Systematic Multi-Issue PR Review**: Fix all issues by priority (Critical→High→Medium→Low) in single commit, not piecemeal - PR #14 fixed 7 issues systematically
-- **Critical Bug Pattern - State Capture**: Capture state BEFORE mutation/replacement - `final_best_strategy` bug showed importance of returning data before civilizations replaced
-- **Function Signature Evolution**: When changing return type (float → tuple), grep for ALL call sites and update - missed call site = runtime error
-- **Edge Case ZeroDivisionError**: Always handle zero denominators in statistical calculations (baseline_mean=0, df_den=0)
-- **DRY During Review**: Extract duplicates immediately when spotted, not "later" - LLM cost summary and convergence logic extracted during PR #14 review
-- **Post-Commit Review Handling**: Reviews can arrive AFTER you push fixes - always check feedback timestamps vs commit time
-- **Duplicate RNG Seeding Anti-Pattern**: Seeding in main() and __init__() causes second to overwrite first - seed only where randomness is used
-- **Parent Selection in Genetic Algorithms**: Use `random.sample(population, k)` not multiple `random.choice()` calls to ensure distinct parents
-- **Temperature Inversion**: Always verify exploration→exploitation patterns in evolutionary algorithms
+- **GraphQL for Complete PR Feedback** (PR #18): Use single GraphQL query instead of multiple REST calls - REST returns 404 on empty collections, GraphQL returns empty arrays. Created `/tmp/pr_feedback_query.gql` with atomic query fetching comments, reviews, line comments, CI annotations - zero missed feedback
+- **Incremental Post-Commit Review** (PR #18): Always check for NEW feedback after pushing fixes using `/fix_pr_since_commit_graphql` - claude-review posted 6 comments AFTER initial fixes pushed
+- **Warning Testing Pattern** (PR #18): Test warning mechanisms with mock patching - `pytest.warns()` + forced non-convergence path. Use `stacklevel=2` in `warnings.warn()` for proper source tracking (prevents B028 lint error)
+- **Bounds Validation Testing** (PR #18): Always test initialization validators with `pytest.raises(ValueError, match="regex")` - validation can exist but remain untested and break silently
+- **Mutation Prevention in Getters** (PR #18): Return `.copy()` from getter methods to prevent external mutation of internal state - defensive programming eliminates subtle bugs
+- **Jupyter Notebook Edge Case Robustness** (PR #16): Always use `.get()` with defaults for JSON keys, check empty collections before operations, handle None before formatting, use conditional expressions for division by zero
+- **Critical Bug Pattern - State Capture** (PR #14): Capture state BEFORE mutation/replacement - `final_best_strategy` bug showed importance of returning data before civilizations replaced
+- **Function Signature Evolution** (PR #14): When changing return type (float → tuple), grep for ALL call sites and update - missed call site = runtime error
 
 ---
 


### PR DESCRIPTION
## Summary
Documentation update for session handover and learnings from PR #18.

## Changes
- **Updated Session Handover in README** with date: October 29, 2025 06:30 PM JST
- **Added 5 critical learnings to CLAUDE.md**:
  1. GraphQL for complete PR feedback coverage (replaces REST 404 issues)
  2. Incremental post-commit review handling (catch late reviewer feedback)
  3. Warning testing pattern with mock patching
  4. Bounds validation testing requirements
  5. Mutation prevention in getter methods
- **Captured next priority tasks**: Documentation polish (LOW priority)
- **Updated global patterns** (~/.claude/):
  - Added GraphQL atomic query pattern to pr-review-guide.md
  - Added 3 new patterns to core-patterns.md

## Session Summary
- **PR #18**: Meta-Learning for Adaptive Operator Selection
- 38 new tests (164 total passing, 1 skipped)
- Fixed 8 reviewer issues + 4 post-commit claude-review issues
- All CI checks passing (Lint, Type check, Tests on Python 3.9/3.10/3.11, CodeRabbit, claude-review)

**Note**: Documentation-only PR, safe for quick merge.