### PR TITLE
data: C1 validation experimental results

### DIFF
--- a/results/c1_validation/C1_RESULTS_SUMMARY.md
+++ b/results/c1_validation/C1_RESULTS_SUMMARY.md
@@ -43,7 +43,7 @@
 **Configuration**:
 - Target number: 961730063 (GNFS sieving optimization)
 - Generations: 20
-- Population size: 15 per generation
+- Population size: 20 per generation
 - Evaluation duration: 1.0 seconds per strategy
 - Random seeds: 1000-1009 (10 independent runs)
 
@@ -307,7 +307,7 @@ All figures available in PNG (300 DPI) and SVG (vector) formats.
 ```bash
 for seed in {1000..1009}; do
   python main.py --prometheus collaborative \
-    --generations 20 --population 15 --duration 1.0 \
+    --generations 20 --population 20 --duration 1.0 \
     --seed $seed --export-metrics results/c1_validation/collaborative_run_${seed}.json
 done
 

--- a/results/c1_validation/rulebased_seed8000.json
+++ b/results/c1_validation/rulebased_seed8000.json
@@ -1,0 +1,52 @@
+{
+  "mode": "prometheus_rulebased",
+  "target_number": 961730063,
+  "generations": 20,
+  "population_size": 20,
+  "random_seed": 8000,
+  "config": {
+    "max_llm_calls": 100,
+    "llm_enabled": false,
+    "temperature_base": 0.8,
+    "temperature_max": 1.2,
+    "max_tokens": 1024,
+    "temperature_scaling_generations": 10,
+    "elite_selection_rate": 0.2,
+    "crossover_rate": 0.3,
+    "mutation_rate": 0.5,
+    "evaluation_duration": 1.0,
+    "meta_learning_min_rate": 0.1,
+    "meta_learning_max_rate": 0.7,
+    "adaptation_window": 5,
+    "fallback_inf_rate": 0.8,
+    "fallback_finite_rate": 0.2,
+    "power_min": 2,
+    "power_max": 5,
+    "max_filters": 4,
+    "min_hits_min": 1,
+    "min_hits_max": 6,
+    "mutation_prob_power": 0.3,
+    "mutation_prob_filter": 0.3,
+    "mutation_prob_modulus": 0.5,
+    "mutation_prob_residue": 0.5,
+    "mutation_prob_add_filter": 0.15,
+    "prometheus_enabled": true,
+    "prometheus_mode": "rulebased",
+    "max_api_cost": 1.0
+  },
+  "best_fitness": 626117,
+  "best_strategy": {
+    "power": 3,
+    "modulus_filters": [
+      [
+        2,
+        [
+          0,
+          1
+        ]
+      ]
+    ],
+    "smoothness_bound": 17,
+    "min_small_prime_hits": 1
+  }
+}

--- a/results/c1_validation/rulebased_seed8001.json
+++ b/results/c1_validation/rulebased_seed8001.json
@@ -1,0 +1,52 @@
+{
+  "mode": "prometheus_rulebased",
+  "target_number": 961730063,
+  "generations": 20,
+  "population_size": 20,
+  "random_seed": 8001,
+  "config": {
+    "max_llm_calls": 100,
+    "llm_enabled": false,
+    "temperature_base": 0.8,
+    "temperature_max": 1.2,
+    "max_tokens": 1024,
+    "temperature_scaling_generations": 10,
+    "elite_selection_rate": 0.2,
+    "crossover_rate": 0.3,
+    "mutation_rate": 0.5,
+    "evaluation_duration": 1.0,
+    "meta_learning_min_rate": 0.1,
+    "meta_learning_max_rate": 0.7,
+    "adaptation_window": 5,
+    "fallback_inf_rate": 0.8,
+    "fallback_finite_rate": 0.2,
+    "power_min": 2,
+    "power_max": 5,
+    "max_filters": 4,
+    "min_hits_min": 1,
+    "min_hits_max": 6,
+    "mutation_prob_power": 0.3,
+    "mutation_prob_filter": 0.3,
+    "mutation_prob_modulus": 0.5,
+    "mutation_prob_residue": 0.5,
+    "mutation_prob_add_filter": 0.15,
+    "prometheus_enabled": true,
+    "prometheus_mode": "rulebased",
+    "max_api_cost": 1.0
+  },
+  "best_fitness": 590918,
+  "best_strategy": {
+    "power": 3,
+    "modulus_filters": [
+      [
+        2,
+        [
+          0,
+          1
+        ]
+      ]
+    ],
+    "smoothness_bound": 29,
+    "min_small_prime_hits": 1
+  }
+}

--- a/results/c1_validation/rulebased_seed8002.json
+++ b/results/c1_validation/rulebased_seed8002.json
@@ -1,0 +1,52 @@
+{
+  "mode": "prometheus_rulebased",
+  "target_number": 961730063,
+  "generations": 20,
+  "population_size": 20,
+  "random_seed": 8002,
+  "config": {
+    "max_llm_calls": 100,
+    "llm_enabled": false,
+    "temperature_base": 0.8,
+    "temperature_max": 1.2,
+    "max_tokens": 1024,
+    "temperature_scaling_generations": 10,
+    "elite_selection_rate": 0.2,
+    "crossover_rate": 0.3,
+    "mutation_rate": 0.5,
+    "evaluation_duration": 1.0,
+    "meta_learning_min_rate": 0.1,
+    "meta_learning_max_rate": 0.7,
+    "adaptation_window": 5,
+    "fallback_inf_rate": 0.8,
+    "fallback_finite_rate": 0.2,
+    "power_min": 2,
+    "power_max": 5,
+    "max_filters": 4,
+    "min_hits_min": 1,
+    "min_hits_max": 6,
+    "mutation_prob_power": 0.3,
+    "mutation_prob_filter": 0.3,
+    "mutation_prob_modulus": 0.5,
+    "mutation_prob_residue": 0.5,
+    "mutation_prob_add_filter": 0.15,
+    "prometheus_enabled": true,
+    "prometheus_mode": "rulebased",
+    "max_api_cost": 1.0
+  },
+  "best_fitness": 587390,
+  "best_strategy": {
+    "power": 3,
+    "modulus_filters": [
+      [
+        2,
+        [
+          0,
+          1
+        ]
+      ]
+    ],
+    "smoothness_bound": 29,
+    "min_small_prime_hits": 1
+  }
+}

--- a/results/c1_validation/rulebased_seed8003.json
+++ b/results/c1_validation/rulebased_seed8003.json
@@ -1,0 +1,52 @@
+{
+  "mode": "prometheus_rulebased",
+  "target_number": 961730063,
+  "generations": 20,
+  "population_size": 20,
+  "random_seed": 8003,
+  "config": {
+    "max_llm_calls": 100,
+    "llm_enabled": false,
+    "temperature_base": 0.8,
+    "temperature_max": 1.2,
+    "max_tokens": 1024,
+    "temperature_scaling_generations": 10,
+    "elite_selection_rate": 0.2,
+    "crossover_rate": 0.3,
+    "mutation_rate": 0.5,
+    "evaluation_duration": 1.0,
+    "meta_learning_min_rate": 0.1,
+    "meta_learning_max_rate": 0.7,
+    "adaptation_window": 5,
+    "fallback_inf_rate": 0.8,
+    "fallback_finite_rate": 0.2,
+    "power_min": 2,
+    "power_max": 5,
+    "max_filters": 4,
+    "min_hits_min": 1,
+    "min_hits_max": 6,
+    "mutation_prob_power": 0.3,
+    "mutation_prob_filter": 0.3,
+    "mutation_prob_modulus": 0.5,
+    "mutation_prob_residue": 0.5,
+    "mutation_prob_add_filter": 0.15,
+    "prometheus_enabled": true,
+    "prometheus_mode": "rulebased",
+    "max_api_cost": 1.0
+  },
+  "best_fitness": 629592,
+  "best_strategy": {
+    "power": 3,
+    "modulus_filters": [
+      [
+        2,
+        [
+          0,
+          1
+        ]
+      ]
+    ],
+    "smoothness_bound": 17,
+    "min_small_prime_hits": 1
+  }
+}

--- a/results/c1_validation/rulebased_seed8004.json
+++ b/results/c1_validation/rulebased_seed8004.json
@@ -1,0 +1,52 @@
+{
+  "mode": "prometheus_rulebased",
+  "target_number": 961730063,
+  "generations": 20,
+  "population_size": 20,
+  "random_seed": 8004,
+  "config": {
+    "max_llm_calls": 100,
+    "llm_enabled": false,
+    "temperature_base": 0.8,
+    "temperature_max": 1.2,
+    "max_tokens": 1024,
+    "temperature_scaling_generations": 10,
+    "elite_selection_rate": 0.2,
+    "crossover_rate": 0.3,
+    "mutation_rate": 0.5,
+    "evaluation_duration": 1.0,
+    "meta_learning_min_rate": 0.1,
+    "meta_learning_max_rate": 0.7,
+    "adaptation_window": 5,
+    "fallback_inf_rate": 0.8,
+    "fallback_finite_rate": 0.2,
+    "power_min": 2,
+    "power_max": 5,
+    "max_filters": 4,
+    "min_hits_min": 1,
+    "min_hits_max": 6,
+    "mutation_prob_power": 0.3,
+    "mutation_prob_filter": 0.3,
+    "mutation_prob_modulus": 0.5,
+    "mutation_prob_residue": 0.5,
+    "mutation_prob_add_filter": 0.15,
+    "prometheus_enabled": true,
+    "prometheus_mode": "rulebased",
+    "max_api_cost": 1.0
+  },
+  "best_fitness": 601584,
+  "best_strategy": {
+    "power": 3,
+    "modulus_filters": [
+      [
+        2,
+        [
+          0,
+          1
+        ]
+      ]
+    ],
+    "smoothness_bound": 23,
+    "min_small_prime_hits": 1
+  }
+}

--- a/results/c1_validation/rulebased_seed8005.json
+++ b/results/c1_validation/rulebased_seed8005.json
@@ -1,0 +1,52 @@
+{
+  "mode": "prometheus_rulebased",
+  "target_number": 961730063,
+  "generations": 20,
+  "population_size": 20,
+  "random_seed": 8005,
+  "config": {
+    "max_llm_calls": 100,
+    "llm_enabled": false,
+    "temperature_base": 0.8,
+    "temperature_max": 1.2,
+    "max_tokens": 1024,
+    "temperature_scaling_generations": 10,
+    "elite_selection_rate": 0.2,
+    "crossover_rate": 0.3,
+    "mutation_rate": 0.5,
+    "evaluation_duration": 1.0,
+    "meta_learning_min_rate": 0.1,
+    "meta_learning_max_rate": 0.7,
+    "adaptation_window": 5,
+    "fallback_inf_rate": 0.8,
+    "fallback_finite_rate": 0.2,
+    "power_min": 2,
+    "power_max": 5,
+    "max_filters": 4,
+    "min_hits_min": 1,
+    "min_hits_max": 6,
+    "mutation_prob_power": 0.3,
+    "mutation_prob_filter": 0.3,
+    "mutation_prob_modulus": 0.5,
+    "mutation_prob_residue": 0.5,
+    "mutation_prob_add_filter": 0.15,
+    "prometheus_enabled": true,
+    "prometheus_mode": "rulebased",
+    "max_api_cost": 1.0
+  },
+  "best_fitness": 630168,
+  "best_strategy": {
+    "power": 3,
+    "modulus_filters": [
+      [
+        2,
+        [
+          0,
+          1
+        ]
+      ]
+    ],
+    "smoothness_bound": 17,
+    "min_small_prime_hits": 1
+  }
+}

--- a/results/c1_validation/rulebased_seed8006.json
+++ b/results/c1_validation/rulebased_seed8006.json
@@ -1,0 +1,52 @@
+{
+  "mode": "prometheus_rulebased",
+  "target_number": 961730063,
+  "generations": 20,
+  "population_size": 20,
+  "random_seed": 8006,
+  "config": {
+    "max_llm_calls": 100,
+    "llm_enabled": false,
+    "temperature_base": 0.8,
+    "temperature_max": 1.2,
+    "max_tokens": 1024,
+    "temperature_scaling_generations": 10,
+    "elite_selection_rate": 0.2,
+    "crossover_rate": 0.3,
+    "mutation_rate": 0.5,
+    "evaluation_duration": 1.0,
+    "meta_learning_min_rate": 0.1,
+    "meta_learning_max_rate": 0.7,
+    "adaptation_window": 5,
+    "fallback_inf_rate": 0.8,
+    "fallback_finite_rate": 0.2,
+    "power_min": 2,
+    "power_max": 5,
+    "max_filters": 4,
+    "min_hits_min": 1,
+    "min_hits_max": 6,
+    "mutation_prob_power": 0.3,
+    "mutation_prob_filter": 0.3,
+    "mutation_prob_modulus": 0.5,
+    "mutation_prob_residue": 0.5,
+    "mutation_prob_add_filter": 0.15,
+    "prometheus_enabled": true,
+    "prometheus_mode": "rulebased",
+    "max_api_cost": 1.0
+  },
+  "best_fitness": 483261,
+  "best_strategy": {
+    "power": 3,
+    "modulus_filters": [
+      [
+        2,
+        [
+          0,
+          1
+        ]
+      ]
+    ],
+    "smoothness_bound": 17,
+    "min_small_prime_hits": 2
+  }
+}

--- a/results/c1_validation/rulebased_seed8007.json
+++ b/results/c1_validation/rulebased_seed8007.json
@@ -1,0 +1,52 @@
+{
+  "mode": "prometheus_rulebased",
+  "target_number": 961730063,
+  "generations": 20,
+  "population_size": 20,
+  "random_seed": 8007,
+  "config": {
+    "max_llm_calls": 100,
+    "llm_enabled": false,
+    "temperature_base": 0.8,
+    "temperature_max": 1.2,
+    "max_tokens": 1024,
+    "temperature_scaling_generations": 10,
+    "elite_selection_rate": 0.2,
+    "crossover_rate": 0.3,
+    "mutation_rate": 0.5,
+    "evaluation_duration": 1.0,
+    "meta_learning_min_rate": 0.1,
+    "meta_learning_max_rate": 0.7,
+    "adaptation_window": 5,
+    "fallback_inf_rate": 0.8,
+    "fallback_finite_rate": 0.2,
+    "power_min": 2,
+    "power_max": 5,
+    "max_filters": 4,
+    "min_hits_min": 1,
+    "min_hits_max": 6,
+    "mutation_prob_power": 0.3,
+    "mutation_prob_filter": 0.3,
+    "mutation_prob_modulus": 0.5,
+    "mutation_prob_residue": 0.5,
+    "mutation_prob_add_filter": 0.15,
+    "prometheus_enabled": true,
+    "prometheus_mode": "rulebased",
+    "max_api_cost": 1.0
+  },
+  "best_fitness": 630267,
+  "best_strategy": {
+    "power": 3,
+    "modulus_filters": [
+      [
+        2,
+        [
+          0,
+          1
+        ]
+      ]
+    ],
+    "smoothness_bound": 17,
+    "min_small_prime_hits": 1
+  }
+}

--- a/results/c1_validation/rulebased_seed8008.json
+++ b/results/c1_validation/rulebased_seed8008.json
@@ -1,0 +1,53 @@
+{
+  "mode": "prometheus_rulebased",
+  "target_number": 961730063,
+  "generations": 20,
+  "population_size": 20,
+  "random_seed": 8008,
+  "config": {
+    "max_llm_calls": 100,
+    "llm_enabled": false,
+    "temperature_base": 0.8,
+    "temperature_max": 1.2,
+    "max_tokens": 1024,
+    "temperature_scaling_generations": 10,
+    "elite_selection_rate": 0.2,
+    "crossover_rate": 0.3,
+    "mutation_rate": 0.5,
+    "evaluation_duration": 1.0,
+    "meta_learning_min_rate": 0.1,
+    "meta_learning_max_rate": 0.7,
+    "adaptation_window": 5,
+    "fallback_inf_rate": 0.8,
+    "fallback_finite_rate": 0.2,
+    "power_min": 2,
+    "power_max": 5,
+    "max_filters": 4,
+    "min_hits_min": 1,
+    "min_hits_max": 6,
+    "mutation_prob_power": 0.3,
+    "mutation_prob_filter": 0.3,
+    "mutation_prob_modulus": 0.5,
+    "mutation_prob_residue": 0.5,
+    "mutation_prob_add_filter": 0.15,
+    "prometheus_enabled": true,
+    "prometheus_mode": "rulebased",
+    "max_api_cost": 1.0
+  },
+  "best_fitness": 556822,
+  "best_strategy": {
+    "power": 3,
+    "modulus_filters": [
+      [
+        3,
+        [
+          0,
+          1,
+          2
+        ]
+      ]
+    ],
+    "smoothness_bound": 29,
+    "min_small_prime_hits": 1
+  }
+}

--- a/results/c1_validation/rulebased_seed8009.json
+++ b/results/c1_validation/rulebased_seed8009.json
@@ -1,0 +1,52 @@
+{
+  "mode": "prometheus_rulebased",
+  "target_number": 961730063,
+  "generations": 20,
+  "population_size": 20,
+  "random_seed": 8009,
+  "config": {
+    "max_llm_calls": 100,
+    "llm_enabled": false,
+    "temperature_base": 0.8,
+    "temperature_max": 1.2,
+    "max_tokens": 1024,
+    "temperature_scaling_generations": 10,
+    "elite_selection_rate": 0.2,
+    "crossover_rate": 0.3,
+    "mutation_rate": 0.5,
+    "evaluation_duration": 1.0,
+    "meta_learning_min_rate": 0.1,
+    "meta_learning_max_rate": 0.7,
+    "adaptation_window": 5,
+    "fallback_inf_rate": 0.8,
+    "fallback_finite_rate": 0.2,
+    "power_min": 2,
+    "power_max": 5,
+    "max_filters": 4,
+    "min_hits_min": 1,
+    "min_hits_max": 6,
+    "mutation_prob_power": 0.3,
+    "mutation_prob_filter": 0.3,
+    "mutation_prob_modulus": 0.5,
+    "mutation_prob_residue": 0.5,
+    "mutation_prob_add_filter": 0.15,
+    "prometheus_enabled": true,
+    "prometheus_mode": "rulebased",
+    "max_api_cost": 1.0
+  },
+  "best_fitness": 602338,
+  "best_strategy": {
+    "power": 3,
+    "modulus_filters": [
+      [
+        2,
+        [
+          0,
+          1
+        ]
+      ]
+    ],
+    "smoothness_bound": 17,
+    "min_small_prime_hits": 1
+  }
+}

--- a/results/c1_validation/search_only_seed7000.json
+++ b/results/c1_validation/search_only_seed7000.json
@@ -1,0 +1,51 @@
+{
+  "mode": "prometheus_search_only",
+  "target_number": 961730063,
+  "generations": 20,
+  "population_size": 20,
+  "random_seed": 7000,
+  "config": {
+    "max_llm_calls": 100,
+    "llm_enabled": false,
+    "temperature_base": 0.8,
+    "temperature_max": 1.2,
+    "max_tokens": 1024,
+    "temperature_scaling_generations": 10,
+    "elite_selection_rate": 0.2,
+    "crossover_rate": 0.3,
+    "mutation_rate": 0.5,
+    "evaluation_duration": 1.0,
+    "meta_learning_min_rate": 0.1,
+    "meta_learning_max_rate": 0.7,
+    "adaptation_window": 5,
+    "fallback_inf_rate": 0.8,
+    "fallback_finite_rate": 0.2,
+    "power_min": 2,
+    "power_max": 5,
+    "max_filters": 4,
+    "min_hits_min": 1,
+    "min_hits_max": 6,
+    "mutation_prob_power": 0.3,
+    "mutation_prob_filter": 0.3,
+    "mutation_prob_modulus": 0.5,
+    "mutation_prob_residue": 0.5,
+    "mutation_prob_add_filter": 0.15,
+    "prometheus_enabled": true,
+    "prometheus_mode": "search_only",
+    "max_api_cost": 1.0
+  },
+  "best_fitness": 475176,
+  "best_strategy": {
+    "power": 2,
+    "modulus_filters": [
+      [
+        2,
+        [
+          0
+        ]
+      ]
+    ],
+    "smoothness_bound": 37,
+    "min_small_prime_hits": 1
+  }
+}

--- a/results/c1_validation/search_only_seed7001.json
+++ b/results/c1_validation/search_only_seed7001.json
@@ -1,0 +1,52 @@
+{
+  "mode": "prometheus_search_only",
+  "target_number": 961730063,
+  "generations": 20,
+  "population_size": 20,
+  "random_seed": 7001,
+  "config": {
+    "max_llm_calls": 100,
+    "llm_enabled": false,
+    "temperature_base": 0.8,
+    "temperature_max": 1.2,
+    "max_tokens": 1024,
+    "temperature_scaling_generations": 10,
+    "elite_selection_rate": 0.2,
+    "crossover_rate": 0.3,
+    "mutation_rate": 0.5,
+    "evaluation_duration": 1.0,
+    "meta_learning_min_rate": 0.1,
+    "meta_learning_max_rate": 0.7,
+    "adaptation_window": 5,
+    "fallback_inf_rate": 0.8,
+    "fallback_finite_rate": 0.2,
+    "power_min": 2,
+    "power_max": 5,
+    "max_filters": 4,
+    "min_hits_min": 1,
+    "min_hits_max": 6,
+    "mutation_prob_power": 0.3,
+    "mutation_prob_filter": 0.3,
+    "mutation_prob_modulus": 0.5,
+    "mutation_prob_residue": 0.5,
+    "mutation_prob_add_filter": 0.15,
+    "prometheus_enabled": true,
+    "prometheus_mode": "search_only",
+    "max_api_cost": 1.0
+  },
+  "best_fitness": 441671,
+  "best_strategy": {
+    "power": 2,
+    "modulus_filters": [
+      [
+        2,
+        [
+          0,
+          1
+        ]
+      ]
+    ],
+    "smoothness_bound": 19,
+    "min_small_prime_hits": 1
+  }
+}

--- a/results/c1_validation/search_only_seed7002.json
+++ b/results/c1_validation/search_only_seed7002.json
@@ -1,0 +1,52 @@
+{
+  "mode": "prometheus_search_only",
+  "target_number": 961730063,
+  "generations": 20,
+  "population_size": 20,
+  "random_seed": 7002,
+  "config": {
+    "max_llm_calls": 100,
+    "llm_enabled": false,
+    "temperature_base": 0.8,
+    "temperature_max": 1.2,
+    "max_tokens": 1024,
+    "temperature_scaling_generations": 10,
+    "elite_selection_rate": 0.2,
+    "crossover_rate": 0.3,
+    "mutation_rate": 0.5,
+    "evaluation_duration": 1.0,
+    "meta_learning_min_rate": 0.1,
+    "meta_learning_max_rate": 0.7,
+    "adaptation_window": 5,
+    "fallback_inf_rate": 0.8,
+    "fallback_finite_rate": 0.2,
+    "power_min": 2,
+    "power_max": 5,
+    "max_filters": 4,
+    "min_hits_min": 1,
+    "min_hits_max": 6,
+    "mutation_prob_power": 0.3,
+    "mutation_prob_filter": 0.3,
+    "mutation_prob_modulus": 0.5,
+    "mutation_prob_residue": 0.5,
+    "mutation_prob_add_filter": 0.15,
+    "prometheus_enabled": true,
+    "prometheus_mode": "search_only",
+    "max_api_cost": 1.0
+  },
+  "best_fitness": 492470,
+  "best_strategy": {
+    "power": 3,
+    "modulus_filters": [
+      [
+        7,
+        [
+          1,
+          6
+        ]
+      ]
+    ],
+    "smoothness_bound": 23,
+    "min_small_prime_hits": 1
+  }
+}

--- a/results/c1_validation/search_only_seed7003.json
+++ b/results/c1_validation/search_only_seed7003.json
@@ -1,0 +1,51 @@
+{
+  "mode": "prometheus_search_only",
+  "target_number": 961730063,
+  "generations": 20,
+  "population_size": 20,
+  "random_seed": 7003,
+  "config": {
+    "max_llm_calls": 100,
+    "llm_enabled": false,
+    "temperature_base": 0.8,
+    "temperature_max": 1.2,
+    "max_tokens": 1024,
+    "temperature_scaling_generations": 10,
+    "elite_selection_rate": 0.2,
+    "crossover_rate": 0.3,
+    "mutation_rate": 0.5,
+    "evaluation_duration": 1.0,
+    "meta_learning_min_rate": 0.1,
+    "meta_learning_max_rate": 0.7,
+    "adaptation_window": 5,
+    "fallback_inf_rate": 0.8,
+    "fallback_finite_rate": 0.2,
+    "power_min": 2,
+    "power_max": 5,
+    "max_filters": 4,
+    "min_hits_min": 1,
+    "min_hits_max": 6,
+    "mutation_prob_power": 0.3,
+    "mutation_prob_filter": 0.3,
+    "mutation_prob_modulus": 0.5,
+    "mutation_prob_residue": 0.5,
+    "mutation_prob_add_filter": 0.15,
+    "prometheus_enabled": true,
+    "prometheus_mode": "search_only",
+    "max_api_cost": 1.0
+  },
+  "best_fitness": 494227,
+  "best_strategy": {
+    "power": 2,
+    "modulus_filters": [
+      [
+        2,
+        [
+          0
+        ]
+      ]
+    ],
+    "smoothness_bound": 31,
+    "min_small_prime_hits": 1
+  }
+}

--- a/results/c1_validation/search_only_seed7004.json
+++ b/results/c1_validation/search_only_seed7004.json
@@ -1,0 +1,52 @@
+{
+  "mode": "prometheus_search_only",
+  "target_number": 961730063,
+  "generations": 20,
+  "population_size": 20,
+  "random_seed": 7004,
+  "config": {
+    "max_llm_calls": 100,
+    "llm_enabled": false,
+    "temperature_base": 0.8,
+    "temperature_max": 1.2,
+    "max_tokens": 1024,
+    "temperature_scaling_generations": 10,
+    "elite_selection_rate": 0.2,
+    "crossover_rate": 0.3,
+    "mutation_rate": 0.5,
+    "evaluation_duration": 1.0,
+    "meta_learning_min_rate": 0.1,
+    "meta_learning_max_rate": 0.7,
+    "adaptation_window": 5,
+    "fallback_inf_rate": 0.8,
+    "fallback_finite_rate": 0.2,
+    "power_min": 2,
+    "power_max": 5,
+    "max_filters": 4,
+    "min_hits_min": 1,
+    "min_hits_max": 6,
+    "mutation_prob_power": 0.3,
+    "mutation_prob_filter": 0.3,
+    "mutation_prob_modulus": 0.5,
+    "mutation_prob_residue": 0.5,
+    "mutation_prob_add_filter": 0.15,
+    "prometheus_enabled": true,
+    "prometheus_mode": "search_only",
+    "max_api_cost": 1.0
+  },
+  "best_fitness": 459608,
+  "best_strategy": {
+    "power": 3,
+    "modulus_filters": [
+      [
+        2,
+        [
+          0,
+          1
+        ]
+      ]
+    ],
+    "smoothness_bound": 17,
+    "min_small_prime_hits": 2
+  }
+}

--- a/results/c1_validation/search_only_seed7005.json
+++ b/results/c1_validation/search_only_seed7005.json
@@ -1,0 +1,53 @@
+{
+  "mode": "prometheus_search_only",
+  "target_number": 961730063,
+  "generations": 20,
+  "population_size": 20,
+  "random_seed": 7005,
+  "config": {
+    "max_llm_calls": 100,
+    "llm_enabled": false,
+    "temperature_base": 0.8,
+    "temperature_max": 1.2,
+    "max_tokens": 1024,
+    "temperature_scaling_generations": 10,
+    "elite_selection_rate": 0.2,
+    "crossover_rate": 0.3,
+    "mutation_rate": 0.5,
+    "evaluation_duration": 1.0,
+    "meta_learning_min_rate": 0.1,
+    "meta_learning_max_rate": 0.7,
+    "adaptation_window": 5,
+    "fallback_inf_rate": 0.8,
+    "fallback_finite_rate": 0.2,
+    "power_min": 2,
+    "power_max": 5,
+    "max_filters": 4,
+    "min_hits_min": 1,
+    "min_hits_max": 6,
+    "mutation_prob_power": 0.3,
+    "mutation_prob_filter": 0.3,
+    "mutation_prob_modulus": 0.5,
+    "mutation_prob_residue": 0.5,
+    "mutation_prob_add_filter": 0.15,
+    "prometheus_enabled": true,
+    "prometheus_mode": "search_only",
+    "max_api_cost": 1.0
+  },
+  "best_fitness": 502544,
+  "best_strategy": {
+    "power": 5,
+    "modulus_filters": [
+      [
+        3,
+        [
+          0,
+          1,
+          2
+        ]
+      ]
+    ],
+    "smoothness_bound": 37,
+    "min_small_prime_hits": 1
+  }
+}

--- a/results/c1_validation/search_only_seed7006.json
+++ b/results/c1_validation/search_only_seed7006.json
@@ -1,0 +1,53 @@
+{
+  "mode": "prometheus_search_only",
+  "target_number": 961730063,
+  "generations": 20,
+  "population_size": 20,
+  "random_seed": 7006,
+  "config": {
+    "max_llm_calls": 100,
+    "llm_enabled": false,
+    "temperature_base": 0.8,
+    "temperature_max": 1.2,
+    "max_tokens": 1024,
+    "temperature_scaling_generations": 10,
+    "elite_selection_rate": 0.2,
+    "crossover_rate": 0.3,
+    "mutation_rate": 0.5,
+    "evaluation_duration": 1.0,
+    "meta_learning_min_rate": 0.1,
+    "meta_learning_max_rate": 0.7,
+    "adaptation_window": 5,
+    "fallback_inf_rate": 0.8,
+    "fallback_finite_rate": 0.2,
+    "power_min": 2,
+    "power_max": 5,
+    "max_filters": 4,
+    "min_hits_min": 1,
+    "min_hits_max": 6,
+    "mutation_prob_power": 0.3,
+    "mutation_prob_filter": 0.3,
+    "mutation_prob_modulus": 0.5,
+    "mutation_prob_residue": 0.5,
+    "mutation_prob_add_filter": 0.15,
+    "prometheus_enabled": true,
+    "prometheus_mode": "search_only",
+    "max_api_cost": 1.0
+  },
+  "best_fitness": 509512,
+  "best_strategy": {
+    "power": 5,
+    "modulus_filters": [
+      [
+        3,
+        [
+          0,
+          1,
+          2
+        ]
+      ]
+    ],
+    "smoothness_bound": 17,
+    "min_small_prime_hits": 1
+  }
+}

--- a/results/c1_validation/search_only_seed7007.json
+++ b/results/c1_validation/search_only_seed7007.json
@@ -1,0 +1,52 @@
+{
+  "mode": "prometheus_search_only",
+  "target_number": 961730063,
+  "generations": 20,
+  "population_size": 20,
+  "random_seed": 7007,
+  "config": {
+    "max_llm_calls": 100,
+    "llm_enabled": false,
+    "temperature_base": 0.8,
+    "temperature_max": 1.2,
+    "max_tokens": 1024,
+    "temperature_scaling_generations": 10,
+    "elite_selection_rate": 0.2,
+    "crossover_rate": 0.3,
+    "mutation_rate": 0.5,
+    "evaluation_duration": 1.0,
+    "meta_learning_min_rate": 0.1,
+    "meta_learning_max_rate": 0.7,
+    "adaptation_window": 5,
+    "fallback_inf_rate": 0.8,
+    "fallback_finite_rate": 0.2,
+    "power_min": 2,
+    "power_max": 5,
+    "max_filters": 4,
+    "min_hits_min": 1,
+    "min_hits_max": 6,
+    "mutation_prob_power": 0.3,
+    "mutation_prob_filter": 0.3,
+    "mutation_prob_modulus": 0.5,
+    "mutation_prob_residue": 0.5,
+    "mutation_prob_add_filter": 0.15,
+    "prometheus_enabled": true,
+    "prometheus_mode": "search_only",
+    "max_api_cost": 1.0
+  },
+  "best_fitness": 544029,
+  "best_strategy": {
+    "power": 3,
+    "modulus_filters": [
+      [
+        2,
+        [
+          0,
+          1
+        ]
+      ]
+    ],
+    "smoothness_bound": 31,
+    "min_small_prime_hits": 1
+  }
+}

--- a/results/c1_validation/search_only_seed7008.json
+++ b/results/c1_validation/search_only_seed7008.json
@@ -1,0 +1,52 @@
+{
+  "mode": "prometheus_search_only",
+  "target_number": 961730063,
+  "generations": 20,
+  "population_size": 20,
+  "random_seed": 7008,
+  "config": {
+    "max_llm_calls": 100,
+    "llm_enabled": false,
+    "temperature_base": 0.8,
+    "temperature_max": 1.2,
+    "max_tokens": 1024,
+    "temperature_scaling_generations": 10,
+    "elite_selection_rate": 0.2,
+    "crossover_rate": 0.3,
+    "mutation_rate": 0.5,
+    "evaluation_duration": 1.0,
+    "meta_learning_min_rate": 0.1,
+    "meta_learning_max_rate": 0.7,
+    "adaptation_window": 5,
+    "fallback_inf_rate": 0.8,
+    "fallback_finite_rate": 0.2,
+    "power_min": 2,
+    "power_max": 5,
+    "max_filters": 4,
+    "min_hits_min": 1,
+    "min_hits_max": 6,
+    "mutation_prob_power": 0.3,
+    "mutation_prob_filter": 0.3,
+    "mutation_prob_modulus": 0.5,
+    "mutation_prob_residue": 0.5,
+    "mutation_prob_add_filter": 0.15,
+    "prometheus_enabled": true,
+    "prometheus_mode": "search_only",
+    "max_api_cost": 1.0
+  },
+  "best_fitness": 566920,
+  "best_strategy": {
+    "power": 3,
+    "modulus_filters": [
+      [
+        2,
+        [
+          0,
+          1
+        ]
+      ]
+    ],
+    "smoothness_bound": 29,
+    "min_small_prime_hits": 1
+  }
+}

--- a/results/c1_validation/search_only_seed7009.json
+++ b/results/c1_validation/search_only_seed7009.json
@@ -1,0 +1,52 @@
+{
+  "mode": "prometheus_search_only",
+  "target_number": 961730063,
+  "generations": 20,
+  "population_size": 20,
+  "random_seed": 7009,
+  "config": {
+    "max_llm_calls": 100,
+    "llm_enabled": false,
+    "temperature_base": 0.8,
+    "temperature_max": 1.2,
+    "max_tokens": 1024,
+    "temperature_scaling_generations": 10,
+    "elite_selection_rate": 0.2,
+    "crossover_rate": 0.3,
+    "mutation_rate": 0.5,
+    "evaluation_duration": 1.0,
+    "meta_learning_min_rate": 0.1,
+    "meta_learning_max_rate": 0.7,
+    "adaptation_window": 5,
+    "fallback_inf_rate": 0.8,
+    "fallback_finite_rate": 0.2,
+    "power_min": 2,
+    "power_max": 5,
+    "max_filters": 4,
+    "min_hits_min": 1,
+    "min_hits_max": 6,
+    "mutation_prob_power": 0.3,
+    "mutation_prob_filter": 0.3,
+    "mutation_prob_modulus": 0.5,
+    "mutation_prob_residue": 0.5,
+    "mutation_prob_add_filter": 0.15,
+    "prometheus_enabled": true,
+    "prometheus_mode": "search_only",
+    "max_api_cost": 1.0
+  },
+  "best_fitness": 620344,
+  "best_strategy": {
+    "power": 3,
+    "modulus_filters": [
+      [
+        2,
+        [
+          0,
+          1
+        ]
+      ]
+    ],
+    "smoothness_bound": 13,
+    "min_small_prime_hits": 1
+  }
+}


### PR DESCRIPTION
## Summary

Add experimental data files from C1 validation experiments to complete the research documentation from PR #49.

## Data Files Added

**20 experimental result files** (total ~24KB):
- `results/c1_validation/rulebased_seed8000.json` through `seed8009.json` (10 files)
- `results/c1_validation/search_only_seed7000.json` through `seed7009.json` (10 files)

## Experimental Configuration

- **Target number**: 961730063 (GNFS sieving optimization)
- **Generations**: 20 per run
- **Population**: 20 strategies per generation
- **Evaluation duration**: 1.0 seconds per strategy
- **Random seeds**: 7000-7009 (search-only), 8000-8009 (rule-based)

## Context

These data files support the C1 validation analysis documented in PR #49:
- **Hypothesis H1a**: NOT SUPPORTED
- **Emergence factor**: 0.954 (collaborative underperformed by 4.6%)
- **Statistical significance**: p = 0.579 (not significant)
- **Effect size**: d = -0.58 (medium negative effect)

The collaborative mode results (seeds 6000-6009) were already committed in PR #47. This PR completes the dataset by adding the two baseline conditions.

## Reproducibility

All experimental data now tracked in git for:
- Full statistical analysis reproducibility
- Independent verification of C1 results
- Future meta-analysis or replication studies

## Changes

- ✅ 20 JSON data files added
- ✅ Documentation population_size corrected (15→20) to match actual experimental data
- ✅ Pre-commit hooks auto-fixed end-of-file formatting
- ✅ No code changes
- ✅ No breaking changes

## Testing

- Pre-commit hooks: ✅ All passing
- Data integrity: ✅ All JSON files valid and parseable
- File size: ✅ All files ~1.2-1.6KB (reasonable for data files)

---

**Note**: Data-only PR, safe for quick merge to complete C1 documentation.