### PR TITLE
docs: session handover and learnings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -608,8 +608,17 @@ Systematic hypothesis verification using pre-registered methodology to validate 
 - **Dependency Completeness for Notebooks**: Check all notebook imports and ensure dependencies are in requirements-dev.txt (e.g., statsmodels for power analysis)
 - **Figure Filename Consistency**: Documentation must reference actual generated filenames - verify script output matches markdown references (e.g., figure2_distribution_analysis.png not figure2_distributions.png)
 
+### Auto-Merge Without Reading Reviews (PR #55, #56, #57)
+- **"Failure Mode #0" Repeated**: Enabled auto-merge on PR #56 without reading reviews first, resulting in post-merge fix PR #57 for incorrect type hint
+- **Root Cause**: Using auto-merge feature bypasses the manual review reading step - creates false sense of completion when CI passes
+- **Pattern**: Auto-merge enables on CI pass → PR merges automatically → Reviews arrive AFTER merge → Post-merge fix PR required
+- **Impact**: PR #57 required to fix `Dict[str, int]` → `Dict[str, Any]` type hint (reviewer caught nested dict structure issue)
+- **Critical Rule**: **NEVER use auto-merge**. Always: (1) Wait for CI ✅ (2) Extract and READ all reviews (3) Address feedback (4) Get approval (5) Manual merge
+- **Why This Matters**: Creates unnecessary churn (3 PRs instead of 1), wastes reviewer time, shows lack of respect for review process
+- **Prevention**: Disable auto-merge feature entirely - removes temptation to skip review reading step
+
 ### C2 Implementation & Critical Review Fixes (PR #52, #53)
-- **"Failure Mode #0" in Practice**: Merged PR #52 without extracting reviews first, missing 6 critical issues from 3 reviewers. Always use GraphQL extraction (`/fix_pr_graphql`) BEFORE merging, even when CI shows "pass" status.
+- **"Failure Mode #0" First Instance**: Merged PR #52 without extracting reviews first, missing 6 critical issues from 3 reviewers. Always use GraphQL extraction (`/fix_pr_graphql`) BEFORE merging, even when CI shows "pass" status.
 - **LLM Temperature Scaling Bug**: Using `getattr(config, 'generations', 20)` always returned 20 (Config has no 'generations' field). Fix: Pass `max_generations` through message payload from experiment → agents → gemini. Critical for exploration→exploitation tradeoff.
 - **ZeroDivisionError Prevention**: Always validate numeric parameters used as divisors. Pattern: `if not isinstance(val, int) or val <= 0: val = DEFAULT`. Add warning logs when fallback occurs for debugging.
 - **Production-Safe Assertions**: Replace `assert isinstance(...)` with explicit `TypeError` - assertions disabled in optimized mode (`python -O`). Pattern: `if not isinstance(...): raise TypeError(f"requires X, got {type(...)}")`.

--- a/README.md
+++ b/README.md
@@ -567,10 +567,30 @@ See `pilot_results_negative_finding.md` for detailed analysis, validity threats,
 
 ## Session Handover
 
-### Last Updated: November 03, 2025 05:57 PM JST
+### Last Updated: November 07, 2025 08:42 PM JST
 
 #### Recently Completed
-- ✅ **PR #53**: Address PR #52 Reviewer Feedback - Critical LLM Temperature Scaling Fixes - MERGED
+- ✅ **PR #57**: Correct comm_stats Type Hint - MERGED (Nov 07)
+  - **Context**: Post-merge fix for PR #56 - failed to read reviews before enabling auto-merge (Failure Mode #0 repeated)
+  - **Issue**: Type hint `Dict[str, int]` incorrect - `comm_stats` contains nested dicts (e.g., `messages_by_type`)
+  - **Fix**: Changed to `Dict[str, Any]` to reflect actual structure
+  - **Learning**: Violated systematic PR review protocol again - must read ALL reviews before merge, never use auto-merge without explicit review reading step
+  - **Impact**: Type hint only (no runtime behavior change), all CI passing ✅
+- ✅ **PR #56**: Generation History Post-Merge Refinements - MERGED (Nov 07)
+  - **Changes**: Precise type hints (`Tuple[float, Strategy, Dict[str, int], List[Dict[str, Any]]]`) and extracted serialization helper (`_serialize_strategy()`)
+  - **Impact**: Improved IDE support, reduced code duplication
+  - **Tests**: All 8 TestGenerationHistoryTracking tests passing ✅
+- ✅ **PR #55**: Generation History Tracking for Gen 0 vs Gen 1 Analysis - MERGED (Nov 07)
+  - **Implementation**: Full population snapshot tracking per generation (fitness, strategies, parameters)
+  - **Core Changes**: `experiment.py` returns 4 values (added generation_history), `main.py` exports to JSON
+  - **Analysis Tool**: `scripts/analyze_gen0_vs_gen1.py` (263 lines) - fitness improvement, diversity analysis
+  - **Key Results** (5 pilots, seeds 9020-9024):
+    - Fitness improvement: 100% success rate, +97K mean (+1000%)
+    - Diversity tradeoff: 70% reduction in power diversity (4.0 → 1.2 unique)
+    - Insight: LLM prioritizes exploitation over exploration in early generations
+  - **Testing**: 8 new tests, all 111 Prometheus tests passing ✅
+  - **Deliverables**: 5 pilot experiments (20 gen × 20 pop = 400 data points each)
+- ✅ **PR #53**: Address PR #52 Reviewer Feedback - Critical LLM Temperature Scaling Fixes - MERGED (Nov 03)
   - **Context**: Merged PR #52 prematurely without extracting reviews (Failure Mode #0), missed 6 critical issues from 3 reviewers
   - **Critical Fixes Applied** (3 commits):
     1. **HIGH Priority - Temperature Scaling Bug**: Fixed `getattr(config, 'generations', 20)` always returning 20. Solution: Pass `max_generations` through payload from experiment → agents → gemini. Critical for exploration→exploitation tradeoff.

--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ See `pilot_results_negative_finding.md` for detailed analysis, validity threats,
   - **Learning**: Violated systematic PR review protocol again - must read ALL reviews before merge, never use auto-merge without explicit review reading step
   - **Impact**: Type hint only (no runtime behavior change), all CI passing ✅
 - ✅ **PR #56**: Generation History Post-Merge Refinements - MERGED (Nov 07)
-  - **Changes**: Precise type hints (`Tuple[float, Strategy, Dict[str, int], List[Dict[str, Any]]]`) and extracted serialization helper (`_serialize_strategy()`)
+  - **Changes**: Refined type hints (`Tuple[float, Strategy, Dict[str, Any], List[Dict[str, Any]]]`) and extracted serialization helper (`_serialize_strategy()`)
   - **Impact**: Improved IDE support, reduced code duplication
   - **Tests**: All 8 TestGenerationHistoryTracking tests passing ✅
 - ✅ **PR #55**: Generation History Tracking for Gen 0 vs Gen 1 Analysis - MERGED (Nov 07)


### PR DESCRIPTION
## Summary
Documentation update for session handover.

## Changes
- Updated Session Handover in README with date: November 07, 2025 08:42 PM JST
- Added Auto-Merge Prohibition Pattern to project CLAUDE.md
- Captured session learnings (PR #55, #56, #57)

## Session Work Completed
- **PR #55**: Generation history tracking for Gen 0 vs Gen 1 analysis
- **PR #56**: Type hints refinement and serialization helper extraction
- **PR #57**: Post-merge type hint fix (comm_stats Dict[str, int] → Dict[str, Any])

## Key Learning: Auto-Merge Prohibition Pattern
**Problem**: GitHub auto-merge systematically bypasses review reading step

**Pattern Observed**:
- PR #52: Manual premature merge → 6 issues missed → PR #53 fix
- PR #56: Auto-merge enabled → Type hint issue → PR #57 fix
- Both show same root: merging before reading reviews

**Solution**: NEVER use auto-merge feature
1. Wait for CI ✅
2. Extract and READ all reviews (use /fix_pr_graphql)
3. Address feedback
4. Get approval
5. Manual merge only

**Why This Matters**: Creates 3 PRs instead of 1, wastes reviewer time

## Global Patterns Updated
(Outside repository, committed separately)
- ~/.claude/CLAUDE.md: Added Auto-Merge Prohibition to PR Review Protocol
- ~/.claude/core-patterns.md: Added Auto-Merge Prohibition Pattern

## Next Priority
C2 validation experiments ready to start (15 runs with --llm flag, seeds 9000-9014)

---

**Note**: Documentation-only PR, safe for quick merge.